### PR TITLE
Remove unused spec to make room for new tests

### DIFF
--- a/spec/monocle_spec.rb
+++ b/spec/monocle_spec.rb
@@ -4,8 +4,4 @@ RSpec.describe Monocle do
   it "has a version number" do
     expect(Monocle::VERSION).not_to be nil
   end
-
-  it "does something useful" do
-    expect(false).to eq(true)
-  end
 end


### PR DESCRIPTION
Closes #8 by removing unused test failing ruby 3.1 check.